### PR TITLE
Collapse whitespace in HTMLMinifier

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,6 +278,7 @@ module.exports = function(grunt) {
             dist: {
                 options: {
                     keepClosingSlash: true,
+                    collapseWhitespace: true,
                     conservativeCollapse: true,
                     minifyCSS: {
                         noAdvanced: true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-compass": "~0.9",
     "grunt-contrib-connect": "~0.8",
     "grunt-contrib-copy": "~0.5",
-    "grunt-contrib-htmlmin": "^0.3.0",
+    "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-imagemin": "~0.7",
     "grunt-contrib-watch": "~0.6",
     "grunt-ejs-render": "~0.2",


### PR DESCRIPTION
When using `conservativeCollapse`, it must go in conjunction with `collapseWhitespace: true`